### PR TITLE
Feature/regexmatches

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -184,7 +184,7 @@ var RootCmd = &cobra.Command{
 func processTemplates(values interface{}, tempDir string) error {
 	return filepath.WalkDir(tempDir, func(p string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && filepath.Ext(p) == ".lgtmpl" {
-			templ, err := internal.GetTemplate().ParseFiles(p)
+			templ, err := internal.GetTemplate(filepath.Base(p)).ParseFiles(p)
 			if err != nil {
 				return err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	cp "github.com/otiai10/copy"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -13,14 +19,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"text/template"
-
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	cp "github.com/otiai10/copy"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 var targetDirectory string
@@ -186,7 +184,7 @@ var RootCmd = &cobra.Command{
 func processTemplates(values interface{}, tempDir string) error {
 	return filepath.WalkDir(tempDir, func(p string, d fs.DirEntry, err error) error {
 		if !d.IsDir() && filepath.Ext(p) == ".lgtmpl" {
-			templ, err := template.ParseFiles(p)
+			templ, err := internal.GetTemplate().ParseFiles(p)
 			if err != nil {
 				return err
 			}

--- a/internal/templating.go
+++ b/internal/templating.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"regexp"
+	"text/template"
+)
+
+// templating.go contains, primarily, extra functions for templating.
+
+var TemplatingExtensions = template.FuncMap{
+	"regexMatch": func(pattern, str string) bool {
+		matched, _ := regexp.MatchString(pattern, str)
+		return matched
+	},
+}
+
+func GetTemplate() *template.Template {
+	return template.New("LagoonsyncTemplate").Funcs(TemplatingExtensions)
+}

--- a/internal/templating.go
+++ b/internal/templating.go
@@ -14,6 +14,6 @@ var TemplatingExtensions = template.FuncMap{
 	},
 }
 
-func GetTemplate() *template.Template {
-	return template.New("LagoonsyncTemplate").Funcs(TemplatingExtensions)
+func GetTemplate(name string) *template.Template {
+	return template.New(name).Funcs(TemplatingExtensions)
 }

--- a/internal/templating_test.go
+++ b/internal/templating_test.go
@@ -41,7 +41,7 @@ func TestGetTemplate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ct := GetTemplate()
+		ct := GetTemplate("")
 		pt, err := ct.Parse(test.template)
 		var buf bytes.Buffer
 		err = pt.Execute(&buf, test.input)

--- a/internal/templating_test.go
+++ b/internal/templating_test.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRegexMatch(t *testing.T) {
+	tests := []struct {
+		pattern string
+		input   string
+		expect  bool
+	}{
+		{"^hello", "hello world", true},
+		{"^world", "hello world", false},
+		{"world$", "hello world", true},
+		{"[0-9]+", "abc123", true},
+		{"^[a-z]{3}$", "abc", true},
+		{"^[a-z]{3}$", "abcd", false},
+		{"[A-Z]+", "lowercase", false},
+		{"[A-Z]+", "UPPERCASE", true},
+	}
+
+	for _, test := range tests {
+		result := TemplatingExtensions["regexMatch"].(func(string, string) bool)(test.pattern, test.input)
+		if result != test.expect {
+			t.Errorf("regexMatch(%q, %q) = %v; want %v", test.pattern, test.input, result, test.expect)
+		}
+	}
+}
+
+func TestGetTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		input    string
+		output   string
+	}{
+		{"templateWithRegexMatch", "{{if regexMatch \"^hello\" .}}Matched!{{else}}No Match{{end}}", "hello world", "Matched!"},
+		{"templateWithRegexMatch", "{{if regexMatch \"^hello\" .}}Matched!{{else}}No Match{{end}}", "goodbye world", "No Match"},
+	}
+
+	for _, test := range tests {
+		ct := GetTemplate()
+		pt, err := ct.Parse(test.template)
+		var buf bytes.Buffer
+		err = pt.Execute(&buf, test.input)
+		if err != nil {
+			return
+		}
+		result := buf.String()
+
+		//result := TemplatingExtensions["regexMatch"].(func(string, string) bool)(test.pattern, test.input)
+		if result != test.output {
+			t.Errorf("parsed template %v, with %v :- Got %v; want %v", test.template, test.input, result, test.output)
+		}
+	}
+}


### PR DESCRIPTION
This feature changes the templating system somewhat and introduces matches based on regexes.

For instance, you're now able to conditionally hide/show/template with regexes

```
environments:
  main:
    cronjobs:
      - name: drush hourly cron
        schedule: "M * * * *"
        command: drush cron
        service: cli
      {{- if regexMatch "myproject" .projectName }}
      - name: My Examples
        schedule: "M * * * *"
        command: echo - hello from my project
        service: cli
      {{- end }}
```